### PR TITLE
Declare build dependency on torch packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "torch", "torchvision"]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ def get_extensions():
 
 setup(
     name="maskrcnn_benchmark",
-    install_requires=["torch", "torchvision"],
     description="object detection in pytorch",
     packages=find_packages(exclude=("configs", "tests",)),
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ def get_extensions():
 
 setup(
     name="maskrcnn_benchmark",
+    install_requires=["torch", "torchvision"],
     description="object detection in pytorch",
     packages=find_packages(exclude=("configs", "tests",)),
     ext_modules=get_extensions(),


### PR DESCRIPTION
This change allows GLIP to be installed via pip alongside torch and torchvision